### PR TITLE
decode session id to string

### DIFF
--- a/quart_session/sessions.py
+++ b/quart_session/sessions.py
@@ -186,7 +186,7 @@ class SessionInterface(QuartSessionInterface):
 
         await self.set(key=session_key, value=val, app=app)
         if self.use_signer:
-            session_id = self._get_signer(app).sign(want_bytes(session.sid))
+            session_id = self._get_signer(app).sign(session.sid).decode()
         else:
             session_id = session.sid
         response.set_cookie(cname, session_id,


### PR DESCRIPTION
This PR solves the [save_session crash with Werkzeug 3.0.1 bug](https://github.com/kroketio/quart-session/issues/18)